### PR TITLE
Jules - Fix Gemma AI model identifier and improve error handling

### DIFF
--- a/app_core/ai_service.py
+++ b/app_core/ai_service.py
@@ -32,7 +32,7 @@ def load_gemma_model():
             st.warning("Hugging Face token (HF_TOKEN) not found in secrets.")
             return None
 
-        model_id = "google/gemma-2-2b-it"
+        model_id = "google/gemma-2b-it"
         model = AutoModelForCausalLM.from_pretrained(
             model_id, torch_dtype=torch.bfloat16, token=hf_token
         ).to("cpu")
@@ -41,7 +41,9 @@ def load_gemma_model():
         st.session_state.gemma_model = {"model": model, "tokenizer": tokenizer}
         return st.session_state.gemma_model
     except Exception as e:
-        st.error(f"Error loading Gemma model: {e}")
+        st.error(f"Error loading Gemma model: {e}. "
+                 "This may be due to a missing or invalid Hugging Face token. "
+                 "Please ensure your `HF_TOKEN` is set correctly in your Streamlit secrets.")
         return None
 
 # This is the main function called by your app.


### PR DESCRIPTION
This commit addresses the connection and loading issue with the offline Gemma model and improves its error handling.

1.  **Fixes the Gemma model identifier.** The Hugging Face model ID for Gemma was incorrect (`google/gemma-2-2b-it`). It has been changed to the proper ID, `google/gemma-2b-it`, resolving the connection/loading issue when switching to the offline model.

2.  **Improves error handling for Gemma.** A more descriptive error message has been added to guide you in troubleshooting Hugging Face token (`HF_TOKEN`) issues, which is the most likely cause of failure when loading the gated Gemma model.

The Vertex AI model name has been kept as `gemini-2.0-flash` per your request.