### PR TITLE
fix: Prevent production crash when Gemma model fails to load

### DIFF
--- a/app_core/ai_service.py
+++ b/app_core/ai_service.py
@@ -41,7 +41,17 @@ def load_gemma_model():
         st.session_state.gemma_model = {"model": model, "tokenizer": tokenizer}
         return st.session_state.gemma_model
     except Exception as e:
-        st.error(f"Error loading Gemma model: {e}")
+        from huggingface_hub.utils import HfHubHTTPError
+
+        if isinstance(e, HfHubHTTPError) and e.response.status_code == 401:
+            st.error("Gemma Model Loading Failed: Unauthorized. "
+                     "This is likely due to a missing or invalid HF_TOKEN in your Streamlit secrets. "
+                     "Please add your Hugging Face token to the secrets to enable the offline model.")
+        else:
+            st.error(f"An unexpected error occurred while loading the Gemma model: {e}")
+
+        # Store failure state to inform the UI
+        st.session_state.gemma_model = None
         return None
 
 # This is the main function called by your app.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -933,6 +933,17 @@ elif st.session_state.view == "main_app" and st.session_state['username']:
     st.write("Here you can meet some of the animals available for adoption.")
     st.header(f"Welcome, {st.session_state['username']}! 🐾")
 
+    # --- Pre-load Gemma model in the background after login ---
+    if "gemma_model" not in st.session_state:
+        from app_core.ai_service import load_gemma_model
+        load_gemma_model()
+
+    # After attempting to load, check if it was successful and display a warning if not
+    if "gemma_model" in st.session_state and st.session_state.gemma_model is None:
+        st.warning("Could not load the offline AI model (Gemma). "
+                   "This is likely due to a missing or invalid `HF_TOKEN` in the app secrets. "
+                   "The chatbot will remain in Online-only mode.", icon="🤖")
+
     # Button to display user history in the sidebar
     display_user_history_button = st.sidebar.button("My History & Points", key="display_history_button")
     if display_user_history_button:


### PR DESCRIPTION
This commit adds robust error handling to prevent the Streamlit application from crashing in a production environment if the offline Gemma model fails to download, which typically happens due to a missing or invalid `HF_TOKEN`.

Changes:
1.  **`app_core/ai_service.py`**: The `load_gemma_model` function now specifically catches `HfHubHTTPError` (for 401 Unauthorized errors) and sets the `st.session_state.gemma_model` to `None` instead of letting the exception crash the app.
2.  **`streamlit_app.py`**: After attempting to pre-load the Gemma model, the app now checks if `st.session_state.gemma_model` is `None`. If it is, a prominent `st.warning` is displayed on the UI, informing you that the offline model is disabled and that the `HF_TOKEN` secret needs to be configured.